### PR TITLE
Add "Consume Mastery Tokens" button to Bank page

### DIFF
--- a/app/src/components/App.tsx
+++ b/app/src/components/App.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { TrackedObject, ObjectType, TrackedObjectList } from './TrackedObject';
 import { Settings, SettingsProvider } from './Settings';
 import styles from '../styles.scss';
+import Bank from './Bank';
 
 interface AppState {
     trackedObjects: TrackedObject[];
@@ -9,6 +10,7 @@ interface AppState {
 }
 export default class App extends Component<{}, AppState> {
     settingsRef = React.createRef<Settings>();
+    bankRef = React.createRef<Bank>();
 
     constructor(props: Readonly<{}>) {
         super(props);
@@ -94,6 +96,7 @@ export default class App extends Component<{}, AppState> {
         return (
             <SettingsProvider>
                 <Settings ref={this.settingsRef} />
+                <Bank ref={this.bankRef} />
                 <div className={'nav-main-heading ' + styles.navMainHeading}>
                     Stat Tracker
                     <i onClick={this.toggleVisibility.bind(this)} className={'far text-muted ' + visibilityIcon} />

--- a/app/src/components/Bank.tsx
+++ b/app/src/components/Bank.tsx
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import Melvor from '../melvor';
+
+export default class Bank extends Component {
+    renderTarget = document.querySelector('#bank-container > div > div:nth-child(2)')!;
+
+    render() {
+        return ReactDOM.createPortal(
+            <button type="button" className="btn btn-lg btn-info ml-2" onClick={this.onConsumeTokens}>
+                Consume Mastery Tokens
+            </button>,
+            this.renderTarget
+        );
+    }
+
+    onConsumeTokens() {
+        for (const id in Melvor.bank) {
+            const item = Melvor.bank[id];
+
+            if (item.category === 'Mastery') {
+                Melvor.claimToken(id, item.id, true);
+            }
+        }
+    }
+}

--- a/app/src/melvor/bindings.ts
+++ b/app/src/melvor/bindings.ts
@@ -7,18 +7,29 @@ interface MelvorItem {
     media: string;
 }
 
+interface MelvorBankItem {
+    id: number;
+    category: string;
+    name: string;
+    type: string;
+    qty: number;
+}
+
 interface MelvorBindings {
     exp: {
         level_to_xp: (level: number) => number;
     };
     numberWithCommas: (number: number) => string;
     convertGP: (gp: number) => string;
+    claimToken: (bankId: string, itemId: number, all?: boolean) => void;
 
     skillLevel: { [skillId: number]: number };
     skillName: { [skillId: number]: string };
     skillXP: { [skillId: number]: number };
 
     items: { [itemId: number]: MelvorItem };
+
+    bank: { [bankSlotId: number]: MelvorBankItem };
 
     CONSTANTS: {
         skill: {


### PR DESCRIPTION
Adds a button to the Bank page to consume all mastery tokens in your bank.

![image](https://user-images.githubusercontent.com/2995953/79973959-bc768200-8498-11ea-9fc0-2e0076bcbe53.png)
